### PR TITLE
feat: test case file format for aggregate functions

### DIFF
--- a/tests/cases/arithmetic/max.test
+++ b/tests/cases/arithmetic/max.test
@@ -1,0 +1,18 @@
+### SUBSTRAIT_SCALAR_TEST: 1.0
+### SUBSTRAIT_INCLUDE: '/extensions/functions_arithmetic.yaml'
+
+# basic: Basic examples without any special cases
+max([20, -3, 1, -10, 0, 5]::i8) = 20::i8
+max([-32768, 32767, 20000, -30000]::i16) = 32767::i16
+max([-214748648, 214748647, 21470048, 4000000]::i32) = 214748647::i32
+max([2000000000, -3217908979, 629000000, -100000000, 0, 987654321]::i64) = 2000000000::i64
+max([2.5, 0, 5.0, -2.5, -7.5]::fp32) = 5.0::fp32
+max([1.5e+308, 1.5e+10, -1.5e+8, -1.5e+7, -1.5e+70]::fp64) = 1.5e+308::fp64
+
+# null_handling: Examples with null as input or output
+max([Null, Null, Null]::i16) = Null::i16
+max([]::i16) = Null::i16
+max([2000000000, Null, 629000000, -100000000, Null, 987654321]::i64) = 2000000000::i64
+max([Null, inf]::fp64) = inf::fp64
+max([Null, -inf, -1.5e+8, -1.5e+7, -1.5e+70]::fp64) = -1.5e+7::fp64
+max([1.5e+308, 1.5e+10, Null, -1.5e+7, Null]::fp64) = 1.5e+308::fp64


### PR DESCRIPTION
`max([20, -3, 1, -10, 0, 5]::i8) = 20::i8`

`corr([20, -3, 1, 10, 5]::fp32, [20, -3, 1, 10, 5]::fp32) = 1::fp64`

`some_agg_func([30, 3, 1, 10]::i32, ['app', 'bat', 'cat', 'dog']::string) = 30::i8`